### PR TITLE
(De)Serializeable model

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rust_nb"
 description = "A simple but generic Naive Bayes Model in Rust."
-version = "0.1.0"
+version = "0.1.1"
 license = "MIT"
 authors = ["Fuyang Liu <liufuyang@users.noreply.github.com>"]
 repository = "https://github.com/liufuyang/rust-nb"
@@ -13,7 +13,8 @@ include = [
 
 [dependencies]
 regex = "1"
-rayon = "1.0"
+rayon = "1.3"
 serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"
+serde_regex = "0.4"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ extern crate rayon;
 extern crate regex;
 #[macro_use]
 extern crate serde_derive;
+extern crate serde_regex;
 
 use rayon::prelude::*;
 use regex::Regex;
@@ -60,11 +61,13 @@ pub trait ModelStore {
     fn get_all_classes(&self, model_name: &str) -> Option<BTreeSet<String>>;
 }
 
+#[derive(Serialize, Deserialize)]
 pub struct Model<T: ModelStore + Sync> {
     // m2 init value, std at the beginning will be sqrt(default_gaussian_m2)
     default_gaussian_m2: f64,
     default_gaussian_sigma_factor: f64,
     model_store: T,
+    #[serde(with = "serde_regex")]
     regex: Regex,
     // Regex used on features, matches will be replaces by empty space. By default we use r"[^a-zA-Z]+" to replace every char not in English as space
     stop_words: Option<HashSet<String>>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -579,7 +579,7 @@ impl<T: ModelStore + Sync> Model<T> {
 
 // A in memory ModelStore implementation ModelHashMapStore
 
-#[derive(Debug)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct ModelHashMapStore {
     map: HashMap<String, f64>,
     class_map: HashMap<String, BTreeSet<String>>, // model_name to list of class


### PR DESCRIPTION
Version bump
Updated `rayon` crate to 1.3

I wasn't able to specify the correct traits [on line 65](https://github.com/eutampieri/rust-nb/blob/9865f63d57b24b677fde58ca1091a7de3e976fbc/src/lib.rs#L65), however it works for me with the default model store.